### PR TITLE
Bugfix: AttributeError 'str' object has no attribute 'get'

### DIFF
--- a/source/infrastructure/amc_insights/microservices/workflow_manager_service/lambdas/DeleteWorkflowSchedule/handler.py
+++ b/source/infrastructure/amc_insights/microservices/workflow_manager_service/lambdas/DeleteWorkflowSchedule/handler.py
@@ -78,9 +78,9 @@ def handler(event, _):
     remove_target_response = events_remove_target(rule_name=rule_name, client=events_client)
 
     if remove_target_response.get('ResponseMetadata', {}).get('HTTPStatusCode', 0) in range(200, 299):
-        logger.info(f"successfully deleted rule target for rule {rule_name.get('Name')}: {remove_target_response}")
+        logger.info(f"successfully deleted rule target for rule {rule_name}: {remove_target_response}")
 
         delete_rule_response = events_delete_rule(rule_name=rule_name, client=events_client)
 
         if delete_rule_response.get('ResponseMetadata', {}).get('HTTPStatusCode', 0) in range(200, 299):
-            logger.info(f"successfully deleted rule {rule_name.get('Name')}: {delete_rule_response}")
+            logger.info(f"successfully deleted rule {rule_name}: {delete_rule_response}")


### PR DESCRIPTION
This bug causes the lambda function to fail every time. And we never get to the line where the EventBridge Rule is ever deleted.

*Issue #, if available: not available.

*Description of changes:
I fixed a bug causing the lambda function to not work as intended. The Lambda should delete the EventBridge Rule but is unable to because it never gets to line 83. This is because line 81 throws an AttributeError 'str' object has no attribute 'get'.

ADDITIONALLY (separate but connected issue) - I think I have found an issue with the actual CloudFormation Template for the Insights solution. Within this Lambda Function's role, one of its policies is missing an Allow on "events:ListTargetsByRule". This will cause the events_get_targets_for_rule function to fail.

Bugs in prod are never fun to encounter, hope this helps you.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
